### PR TITLE
Add Perl Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,10 @@ RUN apt-get update && apt-get install -y \
 		libgd2-dev \
 		libgeoip-dev \
 		libpcre3-dev \
+		libperl-dev \
 		libssl-dev \
-		libxslt1-dev
+		libxslt1-dev \
+		perl
 
 ADD . /usr/src/nginx
 WORKDIR /usr/src/nginx
@@ -24,6 +26,7 @@ RUN ./configure \
 		--with-http_geoip_module \
 		--with-http_gzip_static_module \
 		--with-http_image_filter_module \
+		--with-http_perl_module \
 		--with-http_realip_module \
 		--with-http_spdy_module \
 		--with-http_ssl_module \


### PR DESCRIPTION
Example:

Adding this line to my `nginx.conf` file does not produce an error:

```
perl_set  $rnd 'sub { return int(rand(10 - 5)) + 5; }';
```

Size before:

```
$ docker images
REPOSITORY           TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
nginx                latest              bc32c7487f40        23 minutes ago      444.1 MB
```

Size after:

```
$ docker images
REPOSITORY           TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
nginx                latest              32293f4d9c89        19 seconds ago      458.4 MB
```

Fixes #1
