### PR TITLE
Slightly improved Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN ./configure \
 		--user=www-data \
 		--group=www-data \
 		--prefix=/usr/local/nginx \
-		--conf-path=/etc/nginx.conf \
+		--conf-path=/usr/local/nginx/conf/nginx.conf \
 		--http-log-path=/proc/self/fd/1 \
 		--error-log-path=/proc/self/fd/2 \
 		--with-http_addition_module \
@@ -48,7 +48,10 @@ RUN { \
 		echo; \
 		echo '# stay in the foreground so Docker has a process to track'; \
 		echo 'daemon off;'; \
-	} >> /etc/nginx.conf
+	} >> /usr/local/etc/nginx.conf
+
+# Remove nginx source files after make install
+RUN rm -R /usr/src/*
 
 WORKDIR /usr/local/nginx/html
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,8 @@ RUN { \
 		echo 'daemon off;'; \
 	} >> /usr/local/etc/nginx.conf
 
-# Remove nginx source files after make install
-RUN rm -R /usr/src/*
+# Build cleanup
+RUN rm -R /usr/src/* && apt-get clean
 
 WORKDIR /usr/local/nginx/html
 


### PR DESCRIPTION
I made two minor improvements to the Dockerfile.

My reasons for doing this was to make it easier to use ngnix as a base image. In my case to make a series of packaged web-apps.
- Switched the nginx config back to default location /usr/local/nginx/conf/. Reason being it is easier to use it with volumes. /etc/nginx/ would work as well, but since it is built from source /usr/local is more appropriate.
- Added removal of source files. It may only be around 42MB but it does not belong in the production image.
