### PR TITLE
Feature/configuration volumes

### DIFF
--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -135,7 +135,8 @@ RUN buildDeps=" \
 	&& make -j"$(nproc)" \
 	&& make install \
 	&& cd / \
-	&& rm -r /usr/src/nginx 
+	&& rm -r /usr/src/nginx \
+	&& apt-get purge -y --auto-remove $buildDeps
 # Modify nginx.conf file for Docker use	
 RUN chown -R www-data:www-data /usr/local/nginx \
 	&& chown -R www-data:www-data /nginx \
@@ -144,8 +145,7 @@ RUN chown -R www-data:www-data /usr/local/nginx \
 		echo '# stay in the foreground so Docker has a process to track'; \
 		echo 'daemon off;'; \
 	} >> /nginx/conf/nginx.conf \
-	&& sed -i '0,/server {/s/server {/include \/nginx\/conf.d\/*.conf;\n    server {/' /nginx/conf/nginx.conf \
-	&& apt-get purge -y --auto-remove $buildDeps
+	&& sed -i '0,/server {/s/server {/include \/nginx\/conf.d\/*.conf;\n    server {/' /nginx/conf/nginx.conf 
 
 ENV PATH /usr/local/nginx/sbin:$PATH
 

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -138,7 +138,10 @@ RUN buildDeps=" \
 	&& rm -r /usr/src/nginx \
 	&& apt-get purge -y --auto-remove $buildDeps
 # Modify nginx.conf file for Docker use	
-RUN chown -R www-data:www-data /usr/local/nginx \
+RUN mkdir -p /app \
+	&& mkdir -p /app/logs \
+	&& mkdir -p /usr/local/nginx/conf.d \
+	&& chown -R www-data:www-data /usr/local/nginx \
 	&& chown -R www-data:www-data /app \
 	&& { \
 		echo; \
@@ -147,24 +150,33 @@ RUN chown -R www-data:www-data /usr/local/nginx \
 	} >> /app/conf/nginx.conf \
 	&& sed -i '0,/server {/s/server {/include \/nginx\/conf.d\/*.conf;\n    server {/' /app/conf/nginx.conf 
 
-ENV PATH /usr/local/nginx/sbin:$PATH
+# Add nginx to PATH (both immediately and as part of any future shell attachments)
+ENV PATH /usr/local/nginx/sbin:$PATH 
+RUN { \
+		echo; \
+		echo '# Adding nginx to PATH'; \
+		echo 'export PATH=/usr/local/nginx/sbin:$PATH'; \
+	} >> /etc/bash.bashrc
 
 # TODO USER www-data
 
 # Create symlinks so that volume shares can use compact and consistent pattern
-RUN mkdir -p /usr/local/nginx/conf.d \
-	&& mkdir -p /nginx \
-	&& ln -s /usr/local/nginx/conf.d /app/conf.d \
+RUN ln -s /usr/local/nginx/conf.d /app/conf.d \
 	&& ln -s /usr/local/nginx/sockets /app/sockets \
+	&& ln -s /usr/local/nginx/logs /app/logs \
 	&& ln -s /usr/local/nginx/html /app/html
 # Provide host ability to add server directives to configuration
 VOLUME ["/app/conf.d"]
 # Provide host ability to take over all aspects of configuration
+# >	Note: when a user overrides the default config directory is it typical that they only really only want to manipulate
+# 		  the `nginx.conf` file but currently they will need to provide all default configuration files
 VOLUME ["/app/conf"]
 # The "root" directory for all content
 VOLUME ["/app/html"]
 # The directory for all Unix socket files, allowing host to pass socket files as a mutex point (rather than just TCP port)
 VOLUME ["/app/sockets"]
+# Allow host to attach to log file directory
+VOLUME ["/app/logs"]
 
 EXPOSE 80
 ENTRYPOINT ["nginx"]

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -137,13 +137,14 @@ RUN buildDeps=" \
 	&& cd / \
 	&& rm -r /usr/src/nginx 
 # Modify nginx.conf file for Docker use	
-RUN sed -i '0,/server {/s/server {/include \/nginx\/conf.d\/*.conf;\n    server {/' /nginx/conf/nginx.conf \
-	&& chown -R www-data:www-data /usr/local/nginx \
+RUN chown -R www-data:www-data /usr/local/nginx \
+	&& chown -R www-data:www-data /nginx \
 	&& { \
 		echo; \
 		echo '# stay in the foreground so Docker has a process to track'; \
 		echo 'daemon off;'; \
 	} >> /nginx/conf/nginx.conf \
+	&& sed -i '0,/server {/s/server {/include \/nginx\/conf.d\/*.conf;\n    server {/' /nginx/conf/nginx.conf \
 	&& apt-get purge -y --auto-remove $buildDeps
 
 ENV PATH /usr/local/nginx/sbin:$PATH

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -161,4 +161,4 @@ VOLUME ["/nginx/conf.d"]
 VOLUME ["/nginx/conf"]
 
 EXPOSE 80
-CMD ["nginx"]
+ENTRYPOINT ["nginx"]

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -112,7 +112,7 @@ RUN buildDeps=" \
 		--user=www-data \
 		--group=www-data \
 		--prefix=/usr/local/nginx \
-		--conf-path=/etc/nginx.conf \
+		--conf-path=/nginx/conf/nginx.conf \
 		--http-log-path=/proc/self/fd/1 \
 		--error-log-path=/proc/self/fd/2 \
 		--with-http_addition_module \
@@ -135,19 +135,29 @@ RUN buildDeps=" \
 	&& make -j"$(nproc)" \
 	&& make install \
 	&& cd / \
-	&& rm -r /usr/src/nginx \
+	&& rm -r /usr/src/nginx 
+# Modify nginx.conf file for Docker use	
+RUN sed -i '0,/server {/s/server {/include \/nginx\/conf.d\/*.conf;\n    server {/' /nginx/conf/nginx.conf \
 	&& chown -R www-data:www-data /usr/local/nginx \
 	&& { \
 		echo; \
 		echo '# stay in the foreground so Docker has a process to track'; \
 		echo 'daemon off;'; \
-	} >> /etc/nginx.conf \
+	} >> /nginx/conf/nginx.conf \
 	&& apt-get purge -y --auto-remove $buildDeps
 
 ENV PATH /usr/local/nginx/sbin:$PATH
-WORKDIR /usr/local/nginx/html
 
 # TODO USER www-data
+
+# Create functionally explicit sharepoint for additional site config
+RUN mkdir -p /usr/local/nginx/conf.d \
+	&& mkdir -p /nginx \
+	&& ln -s /usr/local/nginx/conf.d /nginx/conf.d
+VOLUME ["/nginx/conf.d"]
+# Offer main configuration directory too; if share accepted host responsible 
+# for config otherwise default is applied
+VOLUME ["/nginx/conf"]
 
 EXPOSE 80
 CMD ["nginx"]

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -155,6 +155,7 @@ ENV PATH /usr/local/nginx/sbin:$PATH
 RUN mkdir -p /usr/local/nginx/conf.d \
 	&& mkdir -p /nginx \
 	&& ln -s /usr/local/nginx/conf.d /app/conf.d \
+	&& ln -s /usr/local/nginx/sockets /app/sockets \
 	&& ln -s /usr/local/nginx/html /app/html
 # Provide host ability to add server directives to configuration
 VOLUME ["/app/conf.d"]
@@ -162,6 +163,8 @@ VOLUME ["/app/conf.d"]
 VOLUME ["/app/conf"]
 # The "root" directory for all content
 VOLUME ["/app/html"]
+# The directory for all Unix socket files, allowing host to pass socket files as a mutex point (rather than just TCP port)
+VOLUME ["/app/sockets"]
 
 EXPOSE 80
 ENTRYPOINT ["nginx"]

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -112,7 +112,7 @@ RUN buildDeps=" \
 		--user=www-data \
 		--group=www-data \
 		--prefix=/usr/local/nginx \
-		--conf-path=/nginx/conf/nginx.conf \
+		--conf-path=/app/conf/nginx.conf \
 		--http-log-path=/proc/self/fd/1 \
 		--error-log-path=/proc/self/fd/2 \
 		--with-http_addition_module \
@@ -139,26 +139,29 @@ RUN buildDeps=" \
 	&& apt-get purge -y --auto-remove $buildDeps
 # Modify nginx.conf file for Docker use	
 RUN chown -R www-data:www-data /usr/local/nginx \
-	&& chown -R www-data:www-data /nginx \
+	&& chown -R www-data:www-data /app \
 	&& { \
 		echo; \
 		echo '# stay in the foreground so Docker has a process to track'; \
 		echo 'daemon off;'; \
-	} >> /nginx/conf/nginx.conf \
-	&& sed -i '0,/server {/s/server {/include \/nginx\/conf.d\/*.conf;\n    server {/' /nginx/conf/nginx.conf 
+	} >> /app/conf/nginx.conf \
+	&& sed -i '0,/server {/s/server {/include \/nginx\/conf.d\/*.conf;\n    server {/' /app/conf/nginx.conf 
 
 ENV PATH /usr/local/nginx/sbin:$PATH
 
 # TODO USER www-data
 
-# Create functionally explicit sharepoint for additional site config
+# Create symlinks so that volume shares can use compact and consistent pattern
 RUN mkdir -p /usr/local/nginx/conf.d \
 	&& mkdir -p /nginx \
-	&& ln -s /usr/local/nginx/conf.d /nginx/conf.d
-VOLUME ["/nginx/conf.d"]
-# Offer main configuration directory too; if share accepted host responsible 
-# for config otherwise default is applied
-VOLUME ["/nginx/conf"]
+	&& ln -s /usr/local/nginx/conf.d /app/conf.d \
+	&& ln -s /usr/local/nginx/html /app/html
+# Provide host ability to add server directives to configuration
+VOLUME ["/app/conf.d"]
+# Provide host ability to take over all aspects of configuration
+VOLUME ["/app/conf"]
+# The "root" directory for all content
+VOLUME ["/app/html"]
 
 EXPOSE 80
 ENTRYPOINT ["nginx"]

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -112,7 +112,7 @@ RUN buildDeps=" \
 		--user=www-data \
 		--group=www-data \
 		--prefix=/usr/local/nginx \
-		--conf-path=/nginx/conf/nginx.conf \
+		--conf-path=/app/conf/nginx.conf \
 		--http-log-path=/proc/self/fd/1 \
 		--error-log-path=/proc/self/fd/2 \
 		--with-http_addition_module \
@@ -139,26 +139,29 @@ RUN buildDeps=" \
 	&& apt-get purge -y --auto-remove $buildDeps
 # Modify nginx.conf file for Docker use	
 RUN chown -R www-data:www-data /usr/local/nginx \
-	&& chown -R www-data:www-data /nginx \
+	&& chown -R www-data:www-data /app \
 	&& { \
 		echo; \
 		echo '# stay in the foreground so Docker has a process to track'; \
 		echo 'daemon off;'; \
 	} >> /nginx/conf/nginx.conf \
-	&& sed -i '0,/server {/s/server {/include \/nginx\/conf.d\/*.conf;\n    server {/' /nginx/conf/nginx.conf 
+	&& sed -i '0,/server {/s/server {/include \/nginx\/conf.d\/*.conf;\n    server {/' /app/conf/nginx.conf 
 
 ENV PATH /usr/local/nginx/sbin:$PATH
 
 # TODO USER www-data
 
-# Create functionally explicit sharepoint for additional site config
+# Create symlinks so that volume shares can use compact and consistent pattern
 RUN mkdir -p /usr/local/nginx/conf.d \
 	&& mkdir -p /nginx \
-	&& ln -s /usr/local/nginx/conf.d /nginx/conf.d
-VOLUME ["/nginx/conf.d"]
-# Offer main configuration directory too; if share accepted host responsible 
-# for config otherwise default is applied
-VOLUME ["/nginx/conf"]
+	&& ln -s /usr/local/nginx/conf.d /app/conf.d \
+	&& ln -s /usr/local/nginx/html /app/html
+# Provide host ability to add server directives to configuration
+VOLUME ["/app/conf.d"]
+# Provide host ability to take over all aspects of configuration
+VOLUME ["/app/conf"]
+# The "root" directory for all content
+VOLUME ["/app/html"]
 
 EXPOSE 80
 ENTRYPOINT ["nginx"]

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -135,7 +135,8 @@ RUN buildDeps=" \
 	&& make -j"$(nproc)" \
 	&& make install \
 	&& cd / \
-	&& rm -r /usr/src/nginx 
+	&& rm -r /usr/src/nginx \
+	&& apt-get purge -y --auto-remove $buildDeps
 # Modify nginx.conf file for Docker use	
 RUN chown -R www-data:www-data /usr/local/nginx \
 	&& chown -R www-data:www-data /nginx \
@@ -144,8 +145,7 @@ RUN chown -R www-data:www-data /usr/local/nginx \
 		echo '# stay in the foreground so Docker has a process to track'; \
 		echo 'daemon off;'; \
 	} >> /nginx/conf/nginx.conf \
-	&& sed -i '0,/server {/s/server {/include \/nginx\/conf.d\/*.conf;\n    server {/' /nginx/conf/nginx.conf \
-	&& apt-get purge -y --auto-remove $buildDeps
+	&& sed -i '0,/server {/s/server {/include \/nginx\/conf.d\/*.conf;\n    server {/' /nginx/conf/nginx.conf 
 
 ENV PATH /usr/local/nginx/sbin:$PATH
 

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -138,7 +138,10 @@ RUN buildDeps=" \
 	&& rm -r /usr/src/nginx \
 	&& apt-get purge -y --auto-remove $buildDeps
 # Modify nginx.conf file for Docker use	
-RUN chown -R www-data:www-data /usr/local/nginx \
+RUN mkdir -p /app \
+	&& mkdir -p /app/logs \
+	&& mkdir -p /usr/local/nginx/conf.d \
+	&& chown -R www-data:www-data /usr/local/nginx \
 	&& chown -R www-data:www-data /app \
 	&& { \
 		echo; \
@@ -147,24 +150,33 @@ RUN chown -R www-data:www-data /usr/local/nginx \
 	} >> /app/conf/nginx.conf \
 	&& sed -i '0,/server {/s/server {/include \/nginx\/conf.d\/*.conf;\n    server {/' /app/conf/nginx.conf 
 
-ENV PATH /usr/local/nginx/sbin:$PATH
+# Add nginx to PATH (both immediately and as part of any future shell attachments)
+ENV PATH /usr/local/nginx/sbin:$PATH 
+RUN { \
+		echo; \
+		echo '# Adding nginx to PATH'; \
+		echo 'export PATH=/usr/local/nginx/sbin:$PATH'; \
+	} >> /etc/bash.bashrc
 
 # TODO USER www-data
 
 # Create symlinks so that volume shares can use compact and consistent pattern
-RUN mkdir -p /usr/local/nginx/conf.d \
-	&& mkdir -p /nginx \
-	&& ln -s /usr/local/nginx/conf.d /app/conf.d \
+RUN ln -s /usr/local/nginx/conf.d /app/conf.d \
 	&& ln -s /usr/local/nginx/sockets /app/sockets \
+	&& ln -s /usr/local/nginx/logs /app/logs \
 	&& ln -s /usr/local/nginx/html /app/html
 # Provide host ability to add server directives to configuration
 VOLUME ["/app/conf.d"]
 # Provide host ability to take over all aspects of configuration
+# >	Note: when a user overrides the default config directory is it typical that they only really only want to manipulate
+# 		  the `nginx.conf` file but currently they will need to provide all default configuration files
 VOLUME ["/app/conf"]
 # The "root" directory for all content
 VOLUME ["/app/html"]
 # The directory for all Unix socket files, allowing host to pass socket files as a mutex point (rather than just TCP port)
 VOLUME ["/app/sockets"]
+# Allow host to attach to log file directory
+VOLUME ["/app/logs"]
 
 EXPOSE 80
 ENTRYPOINT ["nginx"]

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -144,7 +144,7 @@ RUN chown -R www-data:www-data /usr/local/nginx \
 		echo; \
 		echo '# stay in the foreground so Docker has a process to track'; \
 		echo 'daemon off;'; \
-	} >> /nginx/conf/nginx.conf \
+	} >> /app/conf/nginx.conf \
 	&& sed -i '0,/server {/s/server {/include \/nginx\/conf.d\/*.conf;\n    server {/' /app/conf/nginx.conf 
 
 ENV PATH /usr/local/nginx/sbin:$PATH
@@ -155,6 +155,7 @@ ENV PATH /usr/local/nginx/sbin:$PATH
 RUN mkdir -p /usr/local/nginx/conf.d \
 	&& mkdir -p /nginx \
 	&& ln -s /usr/local/nginx/conf.d /app/conf.d \
+	&& ln -s /usr/local/nginx/sockets /app/sockets \
 	&& ln -s /usr/local/nginx/html /app/html
 # Provide host ability to add server directives to configuration
 VOLUME ["/app/conf.d"]
@@ -162,6 +163,8 @@ VOLUME ["/app/conf.d"]
 VOLUME ["/app/conf"]
 # The "root" directory for all content
 VOLUME ["/app/html"]
+# The directory for all Unix socket files, allowing host to pass socket files as a mutex point (rather than just TCP port)
+VOLUME ["/app/sockets"]
 
 EXPOSE 80
 ENTRYPOINT ["nginx"]

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -135,13 +135,16 @@ RUN buildDeps=" \
 	&& make -j"$(nproc)" \
 	&& make install \
 	&& cd / \
-	&& rm -r /usr/src/nginx \
-	&& chown -R www-data:www-data /usr/local/nginx \
+	&& rm -r /usr/src/nginx 
+# Modify nginx.conf file for Docker use	
+RUN chown -R www-data:www-data /usr/local/nginx \
+	&& chown -R www-data:www-data /nginx \
 	&& { \
 		echo; \
 		echo '# stay in the foreground so Docker has a process to track'; \
 		echo 'daemon off;'; \
-	} >> /etc/nginx.conf \
+	} >> /nginx/conf/nginx.conf \
+	&& sed -i '0,/server {/s/server {/include \/nginx\/conf.d\/*.conf;\n    server {/' /nginx/conf/nginx.conf \
 	&& apt-get purge -y --auto-remove $buildDeps
 
 ENV PATH /usr/local/nginx/sbin:$PATH
@@ -149,5 +152,15 @@ WORKDIR /usr/local/nginx/html
 
 # TODO USER www-data
 
+# Create functionally explicit sharepoint for additional site config
+RUN mkdir -p /usr/local/nginx/conf.d \
+	&& mkdir -p /nginx \
+	&& ln -s /usr/local/nginx/conf.d /nginx/conf.d
+VOLUME ["/nginx/conf.d"]
+# Do the same for gaining access to core config file
+RUN mkdir -p /nginx/conf \
+	&& ln -s /etc/nginx.conf /nginx/conf/nginx.conf
+VOLUME ["/nginx/conf"]
+
 EXPOSE 80
-CMD ["nginx"]
+ENTRYPOINT ["nginx"]

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -112,7 +112,7 @@ RUN buildDeps=" \
 		--user=www-data \
 		--group=www-data \
 		--prefix=/usr/local/nginx \
-		--conf-path=/etc/nginx.conf \
+		--conf-path=/nginx/conf/nginx.conf \
 		--http-log-path=/proc/self/fd/1 \
 		--error-log-path=/proc/self/fd/2 \
 		--with-http_addition_module \
@@ -148,7 +148,6 @@ RUN chown -R www-data:www-data /usr/local/nginx \
 	&& apt-get purge -y --auto-remove $buildDeps
 
 ENV PATH /usr/local/nginx/sbin:$PATH
-WORKDIR /usr/local/nginx/html
 
 # TODO USER www-data
 
@@ -157,9 +156,8 @@ RUN mkdir -p /usr/local/nginx/conf.d \
 	&& mkdir -p /nginx \
 	&& ln -s /usr/local/nginx/conf.d /nginx/conf.d
 VOLUME ["/nginx/conf.d"]
-# Do the same for gaining access to core config file
-RUN mkdir -p /nginx/conf \
-	&& ln -s /etc/nginx.conf /nginx/conf/nginx.conf
+# Offer main configuration directory too; if share accepted host responsible 
+# for config otherwise default is applied
 VOLUME ["/nginx/conf"]
 
 EXPOSE 80


### PR DESCRIPTION
This combines what was discussed in PR #11 but adds two levels of configuration:
- Automatic Config
  - Just run it ... `sudo docker run -d nginx:1.x`
  - You get standard config as it runs today
- New Service Config
  - Added in a volume share `/nginx/conf.d` which allows new server sections to be added on a shared volume
  - The existing server config (aka, port 80) is still in play as are all the default settings in the "http" section
- Complete Control
  - Added another share under `/nginx/conf` which gives the host complete control
  - This allows setting anything wanted in "http" section, allows dynamic template generation of core config
  - Can be done in conjunction or independently of above share

> Note: By choosing `/nginx` as a base for configuration I have opted for a non-unix directory but in effect all I'm aiming to do is provide a compact and explanatory CLI for the host. Not sure if you'll agree with my thinking but I hope so ... I tend to fall in love with my own ideas.
> 
> Last comment ... I'm sorry I couldn't have just let PR #11 run it's course but I needed something up and running immediately that met my needs. I'd love it if this could be brought back into the fold but if not then thank you for an excellent starting point.
